### PR TITLE
Fix volumes in the docker compose file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     # Need MariaDB because mysql doesn't play nicely with M1 Macs
     image: mariadb:10.7.3
     volumes:
-      - ngi_db_data:/var/lib/mysql
+      - ./db_data:/var/lib/mysql
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: somewordpress
@@ -32,5 +32,3 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DEBUG: "true"
-volumes:
-  ngi_db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,11 @@ version: "3.9"
 
 services:
   ngi_db:
+    container_name: ngi_db
     # Need MariaDB because mysql doesn't play nicely with M1 Macs
     image: mariadb:10.7.3
     volumes:
-      - ./db_data:/var/lib/mysql
+      - ngi_db_data:/var/lib/mysql
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: somewordpress
@@ -14,6 +15,7 @@ services:
       MYSQL_PASSWORD: wordpress
 
   ngi_wordpress:
+    container_name: ngi_wordpress
     depends_on:
       - ngi_db
     image: wordpress:latest
@@ -31,5 +33,4 @@ services:
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DEBUG: "true"
 volumes:
-  db_data: {}
-  wordpress_data: {}
+  ngi_db_data:


### PR DESCRIPTION
The current docker compose file for local development declares two volumes, but doesn't use any.

`wordpress_data` is not used at all, whereas `db_data` is meant to be used, but in fact isn't. Instead, a similarly named directory `./db_data` is created in the local folder. Currently, all data is persisted by [bind mounts](https://docs.docker.com/storage/#choose-the-right-type-of-mount).    

The two volumes that are created are therefore not used or mounted to a container. For example,  running `docker container inspect --format '{{ index .Mounts  }}' ngiswedense_ngi_db_1` returns for me

```
[{bind  /Users/matthias.zepper/Documents/Coding/Websites/ngisweden.se/db_data /var/lib/mysql  rw true rprivate}]
```

In contrast, when running the changes proposed in this PR, the result of `docker container inspect --format '{{ index .Mounts  }}` is:

```
[{volume ngiswedense_ngi_db_data /var/lib/docker/volumes/ngiswedense_ngi_db_data/_data /var/lib/mysql local rw true }]
```

If Docker volumes should be used at all or if binding local directories is actually the simpler solution, is subject to discussion. In that case, the superfluous volumes however should be deleted from the docker compose file. 
