### PR TITLE
Added collab- and tech labels to publications list

### DIFF
--- a/wp-content/themes/ngisweden/functions/shortcodes/ngisweden_publications.php
+++ b/wp-content/themes/ngisweden/functions/shortcodes/ngisweden_publications.php
@@ -142,7 +142,8 @@ function ngisweden_pubs_shortcode($atts_raw){
         $pubs_items[] = '
         <a data-toggle="modal" data-target="#pub_'.$pub['iuid'].'" href="'.$pub['links']['display']['href'].'" target="_blank" class="list-group-item list-group-item-action'.($pub['is_collab'] ? ' list-pub-collab' : '').($pub['is_tech_dev'] ? ' list-pub-techdev' : '').'">
             '.$pub['title'].'<br>
-            <small class="text-muted"><em>'.$pub['journal']['title'].'</em> ('.explode('-', $pub['published'])[0].')</small>
+            <small class="text-muted"><em>'.$pub['journal']['title'].'</em> ('.explode('-', $pub['published'])[0].')</small>'
+            .($pub['is_collab'] ? '<span class="float-right badge badge-primary mt-3">NGI Collaboration</span>' : '').($pub['is_tech_dev'] ? '<span class="float-right badge badge-success mt-3 mr-1">NGI Technology development</span>' : '').'
         </a>';
 
         // $pubs_items[] = '<pre>'.print_r($pub, true).'</pre>';


### PR DESCRIPTION
I think this [Trello card](https://trello.com/c/ijwdXPkB/95-option-to-add-collaboration-label-on-the-publications-list-on-the-homepage) was forgotten about.

How's this? I also added the tech labels:

![Skärmavbild 2023-04-04 kl  11 29 32](https://user-images.githubusercontent.com/37932118/229750712-0e1dc748-b51f-4e44-a71f-4003eb6946ff.png)
![Skärmavbild 2023-04-04 kl  11 29 42](https://user-images.githubusercontent.com/37932118/229750720-510d1126-7f39-4cda-8e29-b47dec2138b6.png)
