### PR TITLE
Changed size of order button for coming navbar change

### DIFF
--- a/wp-content/themes/ngisweden/style.css
+++ b/wp-content/themes/ngisweden/style.css
@@ -116,6 +116,7 @@ nav.navbar {
         border-color: #4986e7;
     }
     .navbar .new-order-btn {
+        width: 100px;
         font-size: 13px;
         font-weight: 500;
         text-transform: uppercase;


### PR DESCRIPTION
See issue #30 

Without the button size change the navbar would look like this: https://trello.com/c/BV5yI3pp/110-split-services-dropdown-into-applications-and-technologies

With the change it will look as in the screenshot in the issue.

As the navbar is changed in the wordpress admin bar, the new navbar has not yet been implemented.