### PR TITLE
Improve publication fetching routine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,13 @@ wp-admin/
 wp-content/*.php
 wp-content/advanced-cache.php
 wp-content/aiowps_backups/
+wp-content/ai1wm-backups/
 wp-content/backup-db/
 wp-content/backups/
 wp-content/blogs.dir/
 wp-content/cache/
 wp-content/fv-flowplayer-custom/
+wp-content/jetpack-waf/
 wp-content/languages/
 wp-content/mu-plugins/
 wp-content/upgrade/
@@ -34,6 +36,7 @@ wp-content/wp-cache-config.php
 wp-includes/
 wp-snapshots/
 /.htaccess
+/.user.ini
 /license.txt
 /readme.html
 /sitemap.xml

--- a/wp-content/themes/ngisweden/functions/shortcodes/ngisweden_publications.php
+++ b/wp-content/themes/ngisweden/functions/shortcodes/ngisweden_publications.php
@@ -29,7 +29,14 @@ function ngisweden_pubs_shortcode($atts_raw){
 
     // Fetch the cached publications data
     $pubs_json = @file_get_contents(get_template_directory().'/cache/publications_cache.json');
-    $pubs_data = @json_decode($pubs_json, true);
+    if($pubs_json){
+        try {
+            $pubs_data = json_decode($pubs_json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            $warnings[] = 'JSON decode error while fetching cached NGI publications: ' . $exception->getMessage();
+            continue;
+        }
+    }
 
     // Refresh cache if it doesn't exist or is more than a week old
     if(!$pubs_data or $pubs_data['downloaded'] < (time()-(60*60*24*7)) or @count($pubs_data['publications']) == 0 or isset($_GET['refresh'])){
@@ -41,7 +48,12 @@ function ngisweden_pubs_shortcode($atts_raw){
             $pubs_url = 'https://publications.scilifelab.se/label/'.rawurlencode($fac).'.json?limit='.$download_limit;
             $pubs_json = file_get_contents($pubs_url);
             if($pubs_json){
-                $pubs_raw_data = json_decode($pubs_json, true);
+                try {
+                    $pubs_raw_data = json_decode($pubs_json, true, 512, JSON_THROW_ON_ERROR);
+                } catch (\JsonException $exception) {
+                    $warnings[] = 'JSON decode error while fetching NGI publications: ' . $exception->getMessage();
+                    continue;
+                }
                 $new_pubs_data['publications'] = array_merge($new_pubs_data['publications'], $pubs_raw_data['publications']);
             } else {
                 $warnings[] = 'Could not fetch URL: '.$pubs_url;


### PR DESCRIPTION
It seems that fetching a new set of publications to display on our website unfortunately fails at times because of the large memory requirements of that operation:

```
[02-Jan-2025 08:14:09 UTC] PHP Fatal error:  Allowed memory size of 268435456 bytes exhausted (tried to allocate 20480 bytes) in /var/www/html/[ngisweden-dev.scilifelab.se/wp-content/themes/ngisweden/functions/shortcodes/ngisweden_publications.php](http://ngisweden-dev.scilifelab.se/wp-content/themes/ngisweden/functions/shortcodes/ngisweden_publications.php) on line 44
```
I have now tried [to improve the JSON decoding step](https://stackoverflow.com/a/55938252) and doubled the amount of memory in the wp-config.php from 256MB to 512MB. 

However, regardless of the change, the fetching gives a Gateway timeout for the first time and then also subsequently doesn't load the website for a while. But after a minute or so, everything works as expected again and fresh new shiny publications are there. I think [that we need to look into options to execute the publication fetching asynchronously](https://www.php.net/releases/8.1/en.php#fibers).
