### PR TITLE
Revert pull request #50, since the try wrapping unfortunately broke the site.

### DIFF
--- a/wp-content/themes/ngisweden/functions/shortcodes/ngisweden_publications.php
+++ b/wp-content/themes/ngisweden/functions/shortcodes/ngisweden_publications.php
@@ -29,14 +29,7 @@ function ngisweden_pubs_shortcode($atts_raw){
 
     // Fetch the cached publications data
     $pubs_json = @file_get_contents(get_template_directory().'/cache/publications_cache.json');
-    if($pubs_json){
-        try {
-            $pubs_data = json_decode($pubs_json, true, 512, JSON_THROW_ON_ERROR);
-        } catch (\JsonException $exception) {
-            $warnings[] = 'JSON decode error while fetching cached NGI publications: ' . $exception->getMessage();
-            continue;
-        }
-    }
+    $pubs_data = @json_decode($pubs_json, true);
 
     // Refresh cache if it doesn't exist or is more than a week old
     if(!$pubs_data or $pubs_data['downloaded'] < (time()-(60*60*24*7)) or @count($pubs_data['publications']) == 0 or isset($_GET['refresh'])){
@@ -48,12 +41,7 @@ function ngisweden_pubs_shortcode($atts_raw){
             $pubs_url = 'https://publications.scilifelab.se/label/'.rawurlencode($fac).'.json?limit='.$download_limit;
             $pubs_json = file_get_contents($pubs_url);
             if($pubs_json){
-                try {
-                    $pubs_raw_data = json_decode($pubs_json, true, 512, JSON_THROW_ON_ERROR);
-                } catch (\JsonException $exception) {
-                    $warnings[] = 'JSON decode error while fetching NGI publications: ' . $exception->getMessage();
-                    continue;
-                }
+                $pubs_raw_data = json_decode($pubs_json, true);
                 $new_pubs_data['publications'] = array_merge($new_pubs_data['publications'], $pubs_raw_data['publications']);
             } else {
                 $warnings[] = 'Could not fetch URL: '.$pubs_url;


### PR DESCRIPTION
Revert "Wrap JSON decoding for publications into try statement" since it breaks the site. Probably, `try` is not permitted in WordPress themes.

This reverts commit 59c5c78c514a0496b4a43a2694a0e6dbc5220934.