### PR TITLE
Fix accordion block rendering in taxonomy template

### DIFF
--- a/wp-content/themes/ngisweden/archive.php
+++ b/wp-content/themes/ngisweden/archive.php
@@ -197,8 +197,15 @@ get_header(); ?>
   // Blue box with one-line introduction
   echo $page_intro;
 
-  // Echo the rest of the page contents
-  echo $page_contents;
+  // Echo the rest of the page contents (run through the_content so blocks/scripts are processed)
+  if ( ! empty( $page_contents ) && isset( $app_page ) ) {
+    $previous_post = $GLOBALS['post'];
+    $GLOBALS['post'] = $app_page;
+    echo apply_filters( 'the_content', $page_contents );
+    $GLOBALS['post'] = $previous_post;
+  } else {
+    echo apply_filters( 'the_content', $page_contents );
+  }
 
   // Print the tab headers
   echo '<div class="row mt-5 mb-3"><div class="col-sm-2 mb-3"><div class="nav flex-column nav-pills" role="tablist" aria-orientation="vertical">';


### PR DESCRIPTION
On Taxonomy pages, content is pulled from linked pages. When a term has an _application page_ set in term meta, the template loads that page’s rich content as `post_content` into `$page_contents` and echoes it raw at line 201 of [wp-content/themes/ngisweden/archive.php](https://github.com/NationalGenomicsInfrastructure/ngisweden.se/compare/wp-content/themes/ngisweden/archive.php). 

In order to process the raw markup, `do_blocks()` and `content filters` need to be applied, so the blocks are shipped with the associated JS code. Because we were echoing the `post_content` of linked pages raw on taxonomy pages, no such rendering was performed there. Elsewhere the theme does use proper content filters (e.g. `apply_filters('the_content', $page->post_content)`; `the_content()`).

This PR introduces two changes:

- Replace `echo $page_contents`; with `echo apply_filters('the_content', $page_contents)`; block markup is rendered via the` the_content` filter chain.
-  Set global `$post` when outputting that content temporarily, since any script logic that rely on `current post` then sees the linked page instead of the first post in the archive loop. (recommended by AI agent)

## AI-generated explanation of the latter change

### What’s going on

- **Archive context**: In `archive.php` you’re on a taxonomy archive (e.g. an application term). The main loop is over **methods/technologies** posts for that term.
- **Extra content**: You also pull content from a **linked WordPress page** (`$app_page`) and put its raw content in `$page_contents`. You then output that with `apply_filters('the_content', $page_contents)` (lines 199–206).
- So you’re **inside an archive**, but the HTML you’re printing is from **another post** (the app page), not from the current post in the loop.

### Why the global `$post` matters

WordPress (and many blocks/plugins) use the **global `$post`** to know “which post we’re rendering” when:

- Rendering blocks (e.g. “current post” title, featured image, links).
- Running `the_content` filters and block logic that call things like `get_the_ID()`, `get_permalink()`, `get_the_title()`.
- Outputting scripts or markup that depend on “this post’s” data.

At the moment you echo that page content:

- **Without** swapping `$post`: the global is still whatever it was before (typically the **first post in the archive loop** from `have_posts()` / `the_post()`). So any block or script that thinks “current post” will see the **first method/technology**, not the app page.
- **With** swapping: you set `$GLOBALS['post'] = $app_page` so that, while `the_content` runs for `$page_contents`, “current post” is the **linked page**. Blocks and scripts then see the correct post (the one that actually owns that content).

So the logic is: **while outputting content that belongs to `$app_page`, make the global `$post` be `$app_page`**.

### Why only when `$page_contents` is non-empty and `$app_page` is set

- If there’s no linked page or no content, you’re not outputting “another post’s” content, so there’s nothing that should pretend to be that post. No need to touch `$post`.
- Doing it only in the same `if` that fills `$page_contents` keeps the swap **tight**: you only change `$post` when you’re actually about to echo that page’s content.

### Why restore `$previous_post` after the echo

After the block of HTML from the app page, the template continues with the **archive** (tabs, card decks, etc.). Some of that may still use `$post` (e.g. in later loops or template parts). Restoring `$GLOBALS['post'] = $previous_post` puts the context back to what it was (e.g. the last post from the archive loop, or whatever it was before), so the rest of the template doesn’t think “current post” is the app page.

So in short: **set global `$post` to the page whose content you’re outputting, only when you have that content and that page, and restore it afterward so the rest of the archive still sees the correct “current post”.** 

